### PR TITLE
Updating moderator status on LDAP login

### DIFF
--- a/src/main/java/org/mamute/model/User.java
+++ b/src/main/java/org/mamute/model/User.java
@@ -285,6 +285,11 @@ public class User implements Identifiable {
 		this.moderator = true;
 		return this;
 	}
+
+	public User removeModerator() {
+		this.moderator = false;
+		return this;
+	}
 	
 	public boolean canModerate() {
 		return isModerator() || this.karma >= PermissionRulesConstants.MODERATE_EDITS;


### PR DESCRIPTION
Fix for #73. Adds a new method to the `User` model object that allows moderator status to be removed. LDAP logins now check the moderator group on every login rather than just on create.
