### PR TITLE
Bump the maven plugin version to work nice with Mac/Java 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -854,7 +854,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.0</version>
 				<configuration>
 					<source>1.7</source>
 					<target>1.7</target>


### PR DESCRIPTION
Had hard time running mvn package from shell on Mac (worked fine with Ubuntu).
The only thing that really helped was bumping maven plugin.

I am not sure it makes sense to push this to master, so feel free to reject the PR if you think it's dangerous.
