### PR TITLE
Fixes a gravatar bug breaking the tests 

### DIFF
--- a/src/main/resources/mamute-messages.properties
+++ b/src/main/resources/mamute-messages.properties
@@ -578,7 +578,6 @@ comment.flag.other.reason = Reason
 
 # GRAVATAR
 gravatar.url = http://br.gravatar.com
-gravatar.avatar.url = http://www.gravatar.com
 
 # NOTIFICATIONS MAIL
 answer_notification_mail = [{0}] New update at {1}

--- a/src/main/resources/mamute.properties
+++ b/src/main/resources/mamute.properties
@@ -120,3 +120,4 @@ feature.google_search = true
 custom_google_search_key=016122310691742107910:reef2hbhyha
 
 
+gravatar.avatar.url = http://www.gravatar.com

--- a/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
+++ b/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
@@ -66,7 +66,7 @@
 							<li class="nav-item user-item">
 								<tags:userProfileLink user="${currentUser.current}" htmlClass="user-name">
 									<jsp:attribute name="before">
-										<img class="user-image menu-user-image" src="${currentUser.current.getSmallPhoto(t['gravatar.avatar.url'])}"/>
+										<img class="user-image menu-user-image" src="${currentUser.current.getSmallPhoto(env.get('gravatar.avatar.url'))}"/>
 									</jsp:attribute>
 									<jsp:attribute name="after">
 										<span class="reputation" >(${currentUser.current.karma})</span>

--- a/src/main/webapp/WEB-INF/jsp/userProfile/editProfile.jsp
+++ b/src/main/webapp/WEB-INF/jsp/userProfile/editProfile.jsp
@@ -12,7 +12,7 @@
 	</ul>
 </div>
 <div class="image-and-information">
-	<img class="profile-image" src="${user.getBigPhoto(t['gravatar.avatar.url'])}"/>
+	<img class="profile-image" src="${user.getBigPhoto(env.get('gravatar.avatar.url'))}"/>
 	<a href="${t['gravatar.url']}">${t['user_profile.edit.photo']}</a>
 </div>
 

--- a/src/main/webapp/WEB-INF/tags/RankingUser.tag
+++ b/src/main/webapp/WEB-INF/tags/RankingUser.tag
@@ -6,7 +6,7 @@
 <%@attribute name="isTagRanking" required="false" %>
 
 <div class="ranking-user">
-	<img class="user-image" src="${isTagRanking ? user.getSmallPhoto(t['gravatar.avatar.url']) : user.getMediumPhoto(t['gravatar.avatar.url'])}"/>
+	<img class="user-image" src="${isTagRanking ? user.getSmallPhoto(t['gravatar.avatar.url']) : user.getMediumPhoto(env.get('gravatar.avatar.url'))}"/>
 	<div class="user-info">
 		<tags:userProfileLink user="${user}" htmlClass="user-name ellipsis"/>
 		<div class="user-karma">${user.karma}<tags:pluralize key="touch.karma" count="${user.karma}" /></div>

--- a/src/main/webapp/WEB-INF/tags/completeUser.tag
+++ b/src/main/webapp/WEB-INF/tags/completeUser.tag
@@ -7,7 +7,7 @@
 <%@attribute name="edited" required="false" %>
 <div class="complete-user">
 	<jsp:doBody/>
-	<img class="user-image" src="${userMediumPhoto ? user.getMediumPhoto(t['gravatar.avatar.url']) : user.getSmallPhoto(t['gravatar.avatar.url'])}"/>
+	<img class="user-image" src="${userMediumPhoto ? user.getMediumPhoto(env.get('gravatar.avatar.url')) : user.getSmallPhoto(env.get('gravatar.avatar.url'))}"/>
 	<div class="user-info" 
 		<c:if test="${microdata}">
 			itemscope itemtype="http://schema.org/Person" itemprop="${edited ? 'editor' : 'author'}"

--- a/src/main/webapp/WEB-INF/tags/userProfileTab.tag
+++ b/src/main/webapp/WEB-INF/tags/userProfileTab.tag
@@ -23,7 +23,7 @@
 	</div>
 		
 	<div class="image-and-information">
-		<img class="user-image profile-image" src="${selectedUser.getBigPhoto(t['gravatar.avatar.url'])}"/>
+		<img class="user-image profile-image" src="${selectedUser.getBigPhoto(env.get('gravatar.avatar.url'))}"/>
 		<span class="karma">${selectedUser.karma}</span>
 		<span>${t['user_profile.reputation']}</span>
 	</div>


### PR DESCRIPTION
Bug was introduced in ce2f977480ac27e9da8b08622d76e20cbeef0b0e 
Half of the code in that commit assumes that gravatar.avatar.url has been added to the environment file, other half assumes the language file.
This also breakes the unit tests.

Moving the key to environment file and fixing all the templates to use it.