### PR TITLE
Better UTF 8 support : meta header and default production config

### DIFF
--- a/src/main/resources/production/hibernate.cfg.xml.example
+++ b/src/main/resources/production/hibernate.cfg.xml.example
@@ -4,7 +4,7 @@
         "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
 <hibernate-configuration>
 	<session-factory>
-		<property name="connection.url">jdbc:mysql://localhost/mamute_production</property>
+		<property name="connection.url">jdbc:mysql://localhost/mamute_production?autoReconnect=true&amp;useUnicode=true&amp;characterEncoding=utf-8</property>
 		<property name="connection.driver_class">com.mysql.jdbc.Driver</property>
 		<property name="dialect">org.hibernate.dialect.MySQL5InnoDBDialect</property>
 		<property name="connection.username">root</property>

--- a/src/main/webapp/WEB-INF/tags/header.tag
+++ b/src/main/webapp/WEB-INF/tags/header.tag
@@ -11,6 +11,7 @@
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta http-equiv="content-type" content="text/html; charset=utf-8" />
 <title><c:out value="${title}" escapeXml="true" /></title>
 
 <c:set var="metaDescription" value="${description}" scope="request" />


### PR DESCRIPTION
* setting UTF8 meta tag in header - not having this tag set may cause browser to incorrectly render UTF-8 characters part of certain languages
* adding UTF8 support to JDBC path in hibernate template for production