### PR TITLE
Allow intro tutorial to be optional feature

### DIFF
--- a/src/main/resources/mamute.properties
+++ b/src/main/resources/mamute.properties
@@ -62,6 +62,8 @@ sanitizer.allowed_attributes.img = src, alt, width, height
 #locale=en
 
 #Feature toggle
+#show intro to people with low karma
+feature.intro = true
 
 #every question should have at least one tag)
 feature.tags.mandatory = false

--- a/src/main/webapp/WEB-INF/jsp/coda.jspf
+++ b/src/main/webapp/WEB-INF/jsp/coda.jspf
@@ -117,8 +117,10 @@ function intro(){
 }
 
 $(function() {
-	intro();
-	
+    <c:if test="${environment.supports('feature.intro')}" >
+	    intro();
+    </c:if>
+
 	prettyPrint();
 
 	$("#datepicker-age").pickadate({

--- a/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
+++ b/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
@@ -98,7 +98,7 @@
 								${t['about.link']}
 							</a>
 						</li>
-						<c:if test="${currentUser.loggedIn}">
+						<c:if test="${currentUser.loggedIn && env.supports('feature.intro')}">
 							<li class="nav-item">
 								<a class="intro ${currentUser.current.karma <= 12 ? 'new-users' : ''}" href="#">${t['metas.intro.title']}</a>
 							</li>


### PR DESCRIPTION
Intro can now be disabled, if desired.

Defaults to enabled, so it is backwards compatible