### PR TITLE
Implements LDAP based Single Sign On

### DIFF
--- a/src/main/java/org/mamute/auth/LDAPApi.java
+++ b/src/main/java/org/mamute/auth/LDAPApi.java
@@ -48,6 +48,7 @@ public class LDAPApi {
 	public static final String LDAP_GROUP = "ldap.groupAttr";
 	public static final String LDAP_LOOKUP = "ldap.lookupAttr";
 	public static final String LDAP_MODERATOR_GROUP = "ldap.moderatorGroup";
+	public static final String LDAP_SSO = "ldap.sso";
 	public static final String PLACHOLDER_PASSWORD = "ldap-password-ignore-me";
 
 	@Inject private Environment env;
@@ -109,6 +110,34 @@ public class LDAPApi {
 		} catch (LdapAuthenticationException e) {
 			logger.debug("LDAP auth attempt failed");
 			return false;
+		} catch (LdapException | IOException e) {
+			logger.debug("LDAP connection error", e);
+			throw new AuthenticationException(LDAP_AUTH, "LDAP connection error", e);
+		}
+	}
+
+	/**
+	 * Authenticates a user WITHOUT a password presented. The user name must
+	 * come from a trusted SSO source, e.g. the <code>getRemoteUser()</code>
+	 * from the HTTP Servlet Request.
+	 * 
+	 * @param username
+	 *            User name to authenticate in any case. If no matching user
+	 *            account exists, it is created.
+	 * 
+	 * @return <code>true</code> if the user could be found in LDAP and the User
+	 *         object was initialized, <code>false</code> otherwise.
+	 */
+	public boolean authenticateSSO(String username) {
+
+		try (LDAPResource ldap = new LDAPResource()) {
+			if (ldap.lookupUser(username) == null) {
+				return false;
+			}
+			String cn = userCn(username);
+			createUserIfNeeded(ldap, cn);
+
+			return true;
 		} catch (LdapException | IOException e) {
 			logger.debug("LDAP connection error", e);
 			throw new AuthenticationException(LDAP_AUTH, "LDAP connection error", e);
@@ -265,7 +294,8 @@ public class LDAPApi {
 		}
 
 		private String getAttribute(Entry entry, String attribute) throws LdapException {
-			return entry.get(attribute).getString();
+			Attribute attr = entry.get(attribute);
+			return attr == null ? null : attr.getString();
 		}
 
 		@Override

--- a/src/main/java/org/mamute/auth/LdapSSOFilter.java
+++ b/src/main/java/org/mamute/auth/LdapSSOFilter.java
@@ -1,0 +1,39 @@
+package org.mamute.auth;
+
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+
+import org.mamute.dao.UserDAO;
+import org.mamute.model.LoggedUser;
+import org.mamute.model.User;
+
+import br.com.caelum.vraptor.environment.Environment;
+import br.com.caelum.vraptor.events.MethodReady;
+
+public class LdapSSOFilter {
+
+	@Inject private Environment env;
+	@Inject private UserDAO users;
+	@Inject private LDAPApi ldap;
+	@Inject private LoggedUser loggedUser;
+	@Inject private HttpServletRequest request;
+	@Inject private Access system;
+
+	public void checkSSO(@Observes MethodReady methodReady) {
+		if (env.supports(LDAPApi.LDAP_SSO) && !loggedUser.isLoggedIn() && request.getRequestURI() != null
+				&& !request.getRequestURI().endsWith("/logout")) {
+			String userName = request.getRemoteUser();
+
+			if (userName != null && ldap.authenticateSSO(userName)) {
+				String email = ldap.getEmail(userName);
+				User retrieved = users.findByEmail(email);
+
+				if (retrieved != null) {
+					system.login(retrieved);
+				}
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
This commit implements a Single Sign On for Mamute which loads all required user information for a trusted SSO user name from LDAP. 

We implemented this for use in an Active Directory Environment with Kerberos authentication. To have this working with Mamute, we set up an Apache httpd dealing with Kerberos, setting REMOTE_USER, and forwarding this to an Apache Tomcat. Mamute runs on the Tomcat.

This is not yet tested with Jetty, as I really could not figure out how to easily pass the REMOTE_USER to Jetty WITHOUT using mod_ajp.


To enable SSO, add to your [environment].properties (together with all required LDAP configuration):

ldap.sso = true
