### PR TITLE
Allow including JavaScripts as a first thing in the body

### DIFF
--- a/src/main/webapp/WEB-INF/tags/header.tag
+++ b/src/main/webapp/WEB-INF/tags/header.tag
@@ -86,6 +86,7 @@
 <link rel="canonical" href="${currentUrl}"/>
 </head>
 <body>
+	<tags:brutal-include value="bodyTopJavascripts" />
 
 	<tags:brutal-include value="header" />
 


### PR DESCRIPTION
Adding this include tag as a first thing after opening of the <BODY> HTML tag allows us to include JavaScripts that need to be injected at the very top of the BODY.

Adding empty include in the project which developers can override with their own version in the ``custom`` template folder.