### PR TITLE
Add ability to move logout link to user profile

### DIFF
--- a/src/main/resources/mamute.properties
+++ b/src/main/resources/mamute.properties
@@ -133,3 +133,6 @@ custom_google_search_key=016122310691742107910:reef2hbhyha
 gravatar.avatar.url = http://www.gravatar.com
 
 attachments.root.fs.path = /tmp
+
+# show logout button in the user profile instead of in the main menu
+feature.logout_concealed=false

--- a/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
+++ b/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
@@ -87,11 +87,13 @@
 									</a>
 								</li>
 							</c:if>
-							<li class="nav-item">
-								<a class="logout" href="${linkTo[AuthController].logout}">
-									${t['auth.logout_link']}
-								</a>
-							</li>
+							<c:if test="${!env.supports('feature.logout_concealed')}">
+								<li class="nav-item">
+									<a class="logout" href="${linkTo[AuthController].logout}">
+										${t['auth.logout_link']}
+									</a>
+								</li>
+							</c:if>
 						</c:if>
 						<li class="nav-item">
 							<a class="about" href="${linkTo[NavigationController].about}">

--- a/src/main/webapp/WEB-INF/tags/userProfileTab.tag
+++ b/src/main/webapp/WEB-INF/tags/userProfileTab.tag
@@ -11,6 +11,10 @@
 			<ul class="subheader-menu">
 		<c:if test="${isCurrentUser}">
 				<li><a href="${linkTo[UserProfileController].editProfile(selectedUser)}">${t['user_profile.edit']}</a></li>
+				<c:if test="${env.supports('feature.logout_concealed')}">
+					<li><a href="${linkTo[AuthController].logout}">${t['auth.logout_link']}</a></li>
+				</c:if>
+
 		</c:if>
 				<c:if test="${currentUser.current.isModerator()}">
 					<li>


### PR DESCRIPTION
As many websites are moving away from exposing the logout button too much, this pull request enables site owner to move the 'logout' button out of the main menu into the user profile.