### PR TITLE
Remove new relic key from public repo

### DIFF
--- a/newrelic/newrelic.yml
+++ b/newrelic/newrelic.yml
@@ -14,7 +14,7 @@ common: &default_settings
   # You must specify the license key associated with your New Relic
   # account.  This key binds your Agent's data to your account in the
   # New Relic service.
-  license_key: '0eb53f3d7b4f477a7921f213190d68c42f22a6ba'
+  license_key: 'replace_with_your_license_key'
   
   # Agent Enabled
   # Use this setting to force the agent to run or not run.


### PR DESCRIPTION
This removes your guys' New Relic licence key from the project.

I would go as far as to consider removing entire New Relic folder from the project - this shouldn't be part of the project, at most it's dependency. I am also using New Relic, but have installed it in a separate folder and am injecting the directory in the run script.