### PR TITLE
Extract main tags from the translate file

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
+++ b/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
@@ -6,7 +6,7 @@
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
 
 <header class="header clear">
-<c:set var="mainTags" value="" scope="request"/>
+<c:set var="mainTags" value="${t['tags.featured']}" scope="request"/>
 	<section class="first-header">
 		<div class="container header-container">
 			<a class="logo big-logo sprite"


### PR DESCRIPTION
This allows site owners to use mainTags functionality without overriding a template file.

I plan to prepare PR to move this to database, but don't have time short-term to do it