### PR TITLE
Allow building with Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -681,7 +681,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.5.8.201207111220</version>
+				<version>0.7.5.201505241946</version>
 				<executions>
 					<execution>
 						<goals>
@@ -804,7 +804,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.6.2.201302030002</version>
+				<version>0.7.5.201505241946</version>
 				<configuration>
 					<destfile>${basedir}/target/coverage-reports/jacoco-unit.exec</destfile>
 					<datafile>${basedir}/target/coverage-reports/jacoco-unit.exec</datafile>


### PR DESCRIPTION
JaCoCo versions older than 0.7 do not support Java 8. Updating to the
latest version fixes this.
I have executed the automated tests: all of them are successful.