### PR TITLE
Add basic docker integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM centos:7
+
+MAINTAINER Jef Verelst, https://github.com/kullervo16
+
+RUN yum install -y unzip java-1.7.0-openjdk java-1.7.0-openjdk-devel && yum clean all
+
+ADD ./target/mamute-*.war /opt/mamute/
+WORKDIR /opt/mamute
+RUN unzip /opt/mamute/mamute-*.war
+ADD docker/startup.sh /opt/mamute/
+RUN chmod +x /opt/mamute/*.sh
+ADD docker/hibernate.cfg.xml /opt/mamute/WEB-INF/classes/development/hibernate.cfg.tmp
+
+EXPOSE 8080
+ENTRYPOINT ["/opt/mamute/startup.sh"]
+
+# variables to specify at startup
+#ENV DB_HOST the host that runs the database
+ENV DB_PORT 3306
+#ENV DB_USER the user to connect to the DB
+#ENV DB_PWD  the password
+#ENV DB_NAME the database name
+ENV MAMUTE_HOST localhost # change this when you want to expose it on a public hostname
+ENV MAMUTE_PORT 8080

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,20 @@
+# mamute
+Dockerfile for Mamute
+-----------
+
+It takes the basic mamute-1.3-0 distribution, adds a script to parameterize the hibernate config file so 
+you can start the container with following options
+
+* DB_HOST : the host of your MySQL installation (or container)
+* DB_USER : the user 
+* DB_PWD : its password
+* DB_NAME : the name of the database
+* DB_PORT : the port running your database.
+* MAMUTE_HOST : the external hostname (defaults to localhost, but change it when you need to access it via another URL)
+* MAMUTE_PORT : the external port (defaults to 8080, but change it when you need to access it via another URL)
+
+This container has been tested together with a default mysql container
+
+
+Example :
+**docker run -ti -e DB_HOST=192.168.1.4 -e DB_USER=mamute -e DB_PWD=mamute_pwd -e DB_NAME=mamute -e DB_PORT=7000 -p 8080:8080 kullervo16/mamute**

--- a/docker/hibernate.cfg.xml
+++ b/docker/hibernate.cfg.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD//EN"
+        "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+<hibernate-configuration>
+        <session-factory>
+                <property name="connection.url">jdbc:mysql://HOST:PORT/DATABASE</property>
+                <property name="connection.driver_class">com.mysql.jdbc.Driver</property>
+                <property name="dialect">org.hibernate.dialect.MySQL5InnoDBDialect</property>
+                <property name="connection.username">USER</property>
+                <property name="connection.password">PASSWORD</property>
+                <property name="show_sql">false</property>
+                <property name="format_sql">false</property>
+
+        <property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
+                <property name="hibernate.cache.use_query_cache">false</property>
+                <property name="hibernate.cache.use_second_level_cache">false</property>
+                <property name="hibernate.generate_statistics">false</property>
+
+                <property name="connection.provider_class">org.hibernate.service.jdbc.connections.internal.C3P0ConnectionProvider</property>
+                <property name="c3p0.acquire_increment">1</property>
+                <property name="c3p0.idle_test_period">100</property>
+                <property name="c3p0.max_size">100</property>
+                <property name="c3p0.min_size">10</property>
+                <property name="c3p0.timeout">100</property>
+
+
+                <!-- Nao adicione as classes aqui! Elas ficariam replicadas em 3 xmls!
+                        Deixe somente no SessionFactoryCreator! -->
+
+        </session-factory>
+</hibernate-configuration>
+

--- a/docker/startup.sh
+++ b/docker/startup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo "Configuring database based on environment variables"
+if [ -z "$DB_HOST" ]; then
+    echo "Need to set DB_HOST"
+    exit 1
+fi  
+
+if [ -z "$DB_USER" ]; then
+    echo "Need to set DB_USER"
+    exit 1
+fi
+
+if [ -z "$DB_PWD" ]; then
+    echo "Need to set DB_PWD"
+    exit 1
+fi
+
+if [ -z "$DB_NAME" ]; then
+    echo "Need to set DB_NAME"
+    exit 1
+fi
+
+# now substitute the DB parameters
+sed 's/HOST/'"$DB_HOST"'/g' WEB-INF/classes/development/hibernate.cfg.tmp > WEB-INF/classes/development/hibernate.cfg.tmp2
+sed 's/USER/'"$DB_USER"'/g' WEB-INF/classes/development/hibernate.cfg.tmp2 > WEB-INF/classes/development/hibernate.cfg.tmp3
+sed 's/PORT/'"$DB_PORT"'/g' WEB-INF/classes/development/hibernate.cfg.tmp3 > WEB-INF/classes/development/hibernate.cfg.tmp4
+sed 's/DATABASE/'"$DB_NAME"'/g' WEB-INF/classes/development/hibernate.cfg.tmp4 > WEB-INF/classes/development/hibernate.cfg.tmp5
+sed 's/PASSWORD/'"$DB_PWD"'/g' WEB-INF/classes/development/hibernate.cfg.tmp5 > WEB-INF/classes/development/hibernate.cfg.xml
+
+# then substitute the host parameters
+sed 's/localhost/'"$MAMUTE_HOST"'/g' WEB-INF/classes/mamute.properties > WEB-INF/classes/mamute.properties.tmp
+sed 's/8080/'"$MAMUTE_PORT"'/g' WEB-INF/classes/mamute.properties.tmp > WEB-INF/classes/mamute.properties
+
+echo "Now starting Mamute"
+/opt/mamute/run.sh


### PR DESCRIPTION
As requested, the dockerfile from my build.

I added the Dockerfile in the root since the other build files reside there as well, and docker does not like relative paths that move up the hierarchy... so only the resources are in the docker subfolder.

There are 3 entries there:
* the Readme describing the options you need to launch the container
* the hibernate template with all the placeholders present
* the startup script that does the replacing. It's the v2 of my startup script that also allows the host/port to be changed (otherwise, you get redirects back to localhost when you use a public hostname).

We could discuss if this is the right approach, my aim was to provide the basic things as parameters... if you want full control, you can simply take this as a base and overwrite with your own hibernate/properties file without too much hassle.