### PR TITLE
Fix the layout of the ranking view when there are only a few users

### DIFF
--- a/src/main/webapp/assets/less/ranking.less
+++ b/src/main/webapp/assets/less/ranking.less
@@ -1,5 +1,6 @@
 .ranking {
 	display: inline-block;
+	width: 100%;
 }
 
 .ranking-item {


### PR DESCRIPTION
Whenever there are only few users (this usually happens on the last
page) then each user (ranking-item) is getting very small.
This is because the ranking container shrinks automatically when there
are only a few items and the items themselves are using a relative size.
This is fixed by ensuring that the ranking container always uses the
full width, so the ranking-items are always using 15% of the full width.