### PR TITLE
Fix attachment upload

### DIFF
--- a/src/main/resources/routes.properties
+++ b/src/main/resources/routes.properties
@@ -65,7 +65,7 @@ QuestionController.showQuestion = /{question.id:[0-9]+}-{sluggedTitle}
 QuestionController.newQuestion = /ask
 QuestionController.showVoteInformation = /{question.id:[0-9]+}-{sluggedTitle}/details
 
-AttachmentController.uploadAttachment = /attachments
+AttachmentController.uploadAttachment = /attachments/upload
 AttachmentController.downloadAttachment = /attachments/{attachmentId}
 AttachmentController.deleteAttachment = /attachments/{attachmentId}
 

--- a/src/main/resources/routes.pt-BR.properties
+++ b/src/main/resources/routes.pt-BR.properties
@@ -65,7 +65,7 @@ QuestionController.showQuestion = /{question.id:[0-9]+}-{sluggedTitle}
 QuestionController.newQuestion = /perguntar
 QuestionController.showVoteInformation = /{question.id:[0-9]+}-{sluggedTitle}/details
 
-AttachmentController.uploadAttachment = /attachments
+AttachmentController.uploadAttachment = /attachments/upload
 AttachmentController.downloadAttachment = /attachments/{attachmentId}
 AttachmentController.deleteAttachment = /attachments/{attachmentId}
 

--- a/src/main/webapp/WEB-INF/jsp/coda.jspf
+++ b/src/main/webapp/WEB-INF/jsp/coda.jspf
@@ -12,8 +12,9 @@
 <script type="text/javascript">
 	//UI flags (GLOBAL VARIABLES)
     var Globals = {};
-    Globals.inHouseUploading = ${env.supports('feature.inhouse.upload')};
+	Globals.inHouseUploading = ${env.supports('feature.inhouse.upload')};
 	Globals.linkTo = {};
+	Globals.linkTo.uploadAttachment = "${linkTo[AttachmentController].uploadAttachment}";
 	Globals.linkTo.getAttachment = "${linkTo[AttachmentController].downloadAttachment}";
 
 	var ANYONE_CAN_CREATE_TAGS = ${env.supports('feature.tags.add.anyone')};

--- a/src/main/webapp/assets/js/fileuploader.js
+++ b/src/main/webapp/assets/js/fileuploader.js
@@ -78,7 +78,7 @@ if (Globals.inHouseUploading) {
             }
 
             FileAPI.upload({
-                url: '/attachments',
+                url: Globals.linkTo.uploadAttachment,
                 files: {file: file},
                 complete: uploadCompleted
             });


### PR DESCRIPTION
Currently the attachment upload does not work because jQuery sends the
data to "/attachments" (even after changing the url property to include
the trailing slash in "/attachments/"). Thus I also renamed the route
to /attachments/upload.
This fixes in-house file uploads.