### PR TITLE
Fix translations of the "upvote" and "downvote" tooltips

### DIFF
--- a/src/main/webapp/WEB-INF/tags/answerWith.tag
+++ b/src/main/webapp/WEB-INF/tags/answerWith.tag
@@ -7,7 +7,7 @@
 <%@attribute name="commentVotes" type="org.mamute.model.CommentsAndVotes" required="true" %>
 <section class="post-area ${answer.isVisibleForModeratorAndNotAuthor(currentUser.current) ? 'highlight-post' : '' }">
 	<div class="post-meta">
-		<tags:voteFor item="${answer}" type="${t['answer.type_name']}" vote="${vote}"/>
+		<tags:voteFor item="${answer}" type="Answer" vote="${vote}"/>
 		<tags:solutionMarkFor answer="${answer}"/>
 	</div>
 	<div class="post-container">

--- a/src/main/webapp/WEB-INF/tags/newsWith.tag
+++ b/src/main/webapp/WEB-INF/tags/newsWith.tag
@@ -16,7 +16,7 @@
 		</a>
 	</h1>
 	<div class="post-meta">
-		<tags:voteFor item="${news}" type="${t['news.type_name']}" vote="${currentVote}"/>
+		<tags:voteFor item="${news}" type="News" vote="${currentVote}"/>
 		<tags:watchFor watchable="${news}" type="${t['news.type_name']}"/>
 	</div>
 	<div class="post-container">

--- a/src/main/webapp/WEB-INF/tags/questionWith.tag
+++ b/src/main/webapp/WEB-INF/tags/questionWith.tag
@@ -11,7 +11,7 @@
 		<tags:brutal-include value="questionTopAd" />
 	</c:if>
 	<div class="post-meta">
-		<tags:voteFor item="${question}" type="${t['question.type_name']}" vote="${currentVote}"/>
+		<tags:voteFor item="${question}" type="Question" vote="${currentVote}"/>
 		<tags:watchFor watchable="${question}" type="${t['question.type_name']}"/>
 	</div>
 	<div class="post-container">

--- a/src/main/webapp/WEB-INF/tags/voteFor.tag
+++ b/src/main/webapp/WEB-INF/tags/voteFor.tag
@@ -1,15 +1,17 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions"%>
 <%@attribute name="type" required="true" type="java.lang.String" %>
 <%@attribute name="item" type="org.mamute.model.interfaces.Votable" required="true" %>
 <%@attribute type="org.mamute.model.Vote" name="vote" required="true" %>
+<c:set var="dataType" value="${fn:toLowerCase(type)}.data_type"/>
 <div class="vote-container post-vote">
 	<c:set var="titleUp" value="${type}.upvote"/>
 	<a rel="nofollow" class="container requires-login requires-karma author-cant
 		      up-vote up-arrow arrow vote-option 
 		       ${(not empty vote and vote.countValue == 1) ? 'voted' : '' }"
 		      data-value="positivo" data-author="${currentUser.current.isAuthorOf(item)}"
-		      data-type="${type}"
+		      data-type="${t[dataType]}"
 		      data-karma="${VOTE_UP}"
 		      data-id="${item.id}"
 		      title="${t[titleUp]}">
@@ -22,7 +24,7 @@
 	 		  ${(not empty vote and vote.countValue == -1) ? 'voted' : '' }" 
 	 		  data-value="negativo"  
 	 		  data-author="${currentUser.current.isAuthorOf(item)}"
-	 		  data-type="${type}" 
+			  data-type="${t[dataType]}"
 		      data-karma="${VOTE_DOWN}" 
 	 		  data-id="${item.id}"
 	 		  title="${t[titleDown].args(MY_ANSWER_VOTED_DOWN, DOWNVOTED_QUESTION_OR_ANSWER)}">


### PR DESCRIPTION
Before this change "type" was already translated - then the translated
string was used as part of another localization key (which obviously
does not work).

This issue can also be seen on meta.mamute.org.