### PR TITLE
Fix the gravatar URL on the tag ranking page

### DIFF
--- a/src/main/webapp/WEB-INF/tags/RankingUser.tag
+++ b/src/main/webapp/WEB-INF/tags/RankingUser.tag
@@ -6,7 +6,7 @@
 <%@attribute name="isTagRanking" required="false" %>
 
 <div class="ranking-user">
-	<img class="user-image" src="${isTagRanking ? user.getSmallPhoto(t['gravatar.avatar.url']) : user.getMediumPhoto(env.get('gravatar.avatar.url'))}"/>
+	<img class="user-image" src="${isTagRanking ? user.getSmallPhoto(env.get('gravatar.avatar.url')) : user.getMediumPhoto(env.get('gravatar.avatar.url'))}"/>
 	<div class="user-info">
 		<tags:userProfileLink user="${user}" htmlClass="user-name ellipsis"/>
 		<div class="user-karma">${user.karma}<tags:pluralize key="touch.karma" count="${user.karma}" /></div>


### PR DESCRIPTION
The bug can be seen here: http://meta.mamute.org/ranking/grunt
Image URLs are starting with
```
<span class='i18n_missing_key'>gravatar.avatar.url</span>/avatar/..."
```