### PR TITLE
Fix the German translation for "flag question/answer"

### DIFF
--- a/src/main/resources/mamute-messages_de.properties
+++ b/src/main/resources/mamute-messages_de.properties
@@ -64,7 +64,7 @@ about.tips.greetings = Vermeide Begrüßungen ("Hi Joe", "Meine lieben Freunde"...
 
 about.reputation.permission = Was Du mit Deiner Reputation machen kannst
 about.reputation.upvote = <span class="karma">{0}</span> zum Bewerten beliebiger Fragen/Antworten/Kommentaren
-about.reputation.flag = <span class="karma">{0}</span> zum Markieren beliebiger Fragen/Antworten
+about.reputation.flag = <span class="karma">{0}</span> zum Melden beliebiger Fragen/Antworten
 
 about.reputation.edit.question = <span class="karma">{0}</span> zum Überarbeiten einer Frage
 about.reputation.edit.answer = <span class="karma">{0}</span> zum Überarbeiten einer Antwort
@@ -410,8 +410,8 @@ comment.show_all = Alle {0} Kommentare anzeigen
 comment.remaining_characters = Verbleibende Anzahl Zeichen:
 
 # FLAG COMMENT
-flag.submit = Markieren
-flag = Markierung
+flag.submit = Beitrag melden
+flag = Melden
 
 # QUESTION ACTIONS
 edit = Bearbeiten
@@ -474,10 +474,10 @@ status.refused = Abgelehnt
 # MODERATION
 moderation = Einträge in der Moderationswarteschlange
 moderation.posts = Überarbeitungen
-moderation.flags = Markierungen: {0}
+moderation.flags = Gemeldete Beiträge: {0}
 moderation.edits = Bearbeitungen: {0}
 moderation.flagged.posts = Markierte Einträge
-moderation.flagged.lots = Dieser Eintrag hat 5 oder mehr Markierungen
+moderation.flagged.lots = Dieser Eintrag wurde mindestens 5-mal gemeldet
 moderation.flagged.answers.empty = Keine Fragen zu moderieren
 moderation.flagged.questions.empty = Keine Antworten zu moderieren
 moderation.flagged.comments.empty = Keine Kommentare zu moderieren
@@ -780,7 +780,7 @@ user.moderation.details = Siehe Details
 user.moderation.details.type = Typ
 user.moderation.details.author = Autor
 user.moderation.details.date = Letztmalig aktualisiert
-user.moderation.details.noDetails = Es gibt keine Bewertungen oder Markierungen
+user.moderation.details.noDetails = Es gibt keine Bewertungen oder Meldungen
 user.block_user = Benutzer blockieren
 user.unblock_user = Blockierung des Benutzer aufheben
 


### PR DESCRIPTION
Flagging a question or answer means reporting it to the moderator team.
Thus it should be translated as "melden" instead of "markieren".

CC: @cpfeiffer 