### PR TITLE
Fix viewing profiles with deleted questions

### DIFF
--- a/src/main/java/org/mamute/dao/ReputationEventDAO.java
+++ b/src/main/java/org/mamute/dao/ReputationEventDAO.java
@@ -88,6 +88,12 @@ public class ReputationEventDAO {
 			Long contextId = (Long) row[1];
 			
 			ReputationEventContext context = (ReputationEventContext) session.createQuery("from "+contextClass+" where id = :id").setParameter("id", contextId).uniqueResult();
+
+			// Skip invalid context entries (because the related item can have been deleted).
+			if (context == null) {
+				continue;
+			}
+
 			organizedData.add(new Object[]{
 					context,
 					row[2],

--- a/src/test/java/org/mamute/dao/ReputationEventDAOTest.java
+++ b/src/test/java/org/mamute/dao/ReputationEventDAOTest.java
@@ -240,4 +240,17 @@ public class ReputationEventDAOTest extends DatabaseTestCase {
 		assertEquals(question3Author, summaryForTag.get(1).getUser());
 		assertEquals(1l, summaryForTag.get(1).getCount().longValue());
 	}
+
+	@Test
+	public void should_ignore_events_of_deleted_questions() {
+		session.save(new ReputationEvent(EventType.QUESTION_UPVOTE, questionInvolved1, author));
+
+		session.delete(questionInvolved1);
+
+		KarmaByContextHistory karmaByQuestion = reputationEvents.karmaWonByQuestion(author, new DateTime(0));
+
+		assertNotNull(karmaByQuestion);
+		assertNotNull(karmaByQuestion.getHistory());
+		assertTrue(karmaByQuestion.getHistory().isEmpty());
+	}
 }


### PR DESCRIPTION
Original stacktrace:
java.lang.NullPointerException
	at org.mamute.dto.KarmaByContextHistory.<init>(KarmaByContextHistory.java:19)
	at org.mamute.dao.ReputationEventDAO.karmaByContext(ReputationEventDAO.java:79)
	at org.mamute.dao.ReputationEventDAO.karmaWonByQuestion(ReputationEventDAO.java:62)