### PR TITLE
Jetty server to use HOST system env variable if available

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/server/VRaptorServer.java
+++ b/src/main/java/br/com/caelum/vraptor/server/VRaptorServer.java
@@ -96,12 +96,23 @@ public class VRaptorServer {
 			webPort = System.getProperty("server.port", "8080");
 		}
 		Server server = new Server(Integer.valueOf(webPort));
+		String webHost = getHost();
+		if (webHost == null || webHost.isEmpty()) {
+			webHost = System.getProperty("server.host", "0.0.0.0");
+		}
+		server.getConnectors()[0].setHost(webHost);
+		server.setAttribute("jetty.host", webHost);
 		return server;
 	}
 
 	private static String getPort() {
 		String port = System.getenv("PORT");
 		return port;
+	}
+	
+	private static String getHost() {
+		String host = System.getenv("HOST");
+		return host;
 	}
 
 	public void stop() {


### PR DESCRIPTION
Allows setting Jetty HOST in a fashion similar to setting of PORT
Needed to be able to deploy to Openshift