### PR TITLE
Use HTTP POST when deleting attachments

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/coda.jspf
+++ b/src/main/webapp/WEB-INF/jsp/coda.jspf
@@ -11,11 +11,12 @@
 
 <script type="text/javascript">
 	//UI flags (GLOBAL VARIABLES)
-    var Globals = {};
+	var Globals = {};
 	Globals.inHouseUploading = ${env.supports('feature.inhouse.upload')};
 	Globals.linkTo = {};
 	Globals.linkTo.uploadAttachment = "${linkTo[AttachmentController].uploadAttachment}";
 	Globals.linkTo.getAttachment = "${linkTo[AttachmentController].downloadAttachment}";
+	Globals.linkTo.deleteAttachment = "${linkTo[AttachmentController].deleteAttachment}";
 
 	var ANYONE_CAN_CREATE_TAGS = ${env.supports('feature.tags.add.anyone')};
 	var TAGS_SPLITTER_CHAR = "${env.get('tags.splitter.char')}";

--- a/src/main/webapp/assets/js/fileuploader.js
+++ b/src/main/webapp/assets/js/fileuploader.js
@@ -11,8 +11,9 @@ if (Globals.inHouseUploading) {
             link.css("pointer-events", "none");
             var id = link.data("attachment-id");
             $.ajax({
-                url: Globals.linkTo.getAttachment + id,
-                type: 'DELETE',
+                url: Globals.linkTo.deleteAttachment + id,
+                method: 'POST',
+                data: { _method: 'DELETE' },
                 success: function(result) {
                     $("#attachment-" + id).remove();
                     $("#input-attachment-" + id).remove();


### PR DESCRIPTION
This fixes deleting attachments on tomcat where HTTP DELETE (and PUT)
are disabled by default. Enabling them is also not possible because that
would allow users to delete attachments if they know the id of the
attachment on the file-system (for example with curl, by running
curl -X DELETE http://mamute.local/attachments/1).