### PR TITLE
Don't include the filepicker.io JS when using inhouse file upload

### DIFF
--- a/src/main/webapp/WEB-INF/jsp/coda.jspf
+++ b/src/main/webapp/WEB-INF/jsp/coda.jspf
@@ -61,14 +61,19 @@
 	</c:when>
 </c:choose>
 
+<c:if test="${not env.supports('feature.inhouse.upload')}">
+	<!-- build:js /js/filepicker.js -->
+		<script src="/assets/js/deps/filepicker.js"></script>
+		<script src="/assets/js/deps/feather.js"></script>
+	<!-- endbuild -->
+</c:if>
+
 <!-- build:js /js/mamute.js -->
 	<script src="/assets/js/deps/prettify.js"></script>
 	<script src="/assets/js/deps/Markdown.Converter.js"></script>
 	<script src="/assets/js/deps/Markdown.Sanitizer.js"></script>
 	<script src="/assets/js/deps/Markdown.Editor.js"></script>
 	<script src="/assets/js/deps/marked.js"></script>
-	<script src="/assets/js/deps/filepicker.js"></script>
-	<script src="/assets/js/deps/feather.js"></script>
 	<script src="/assets/js/messages.js"></script>
 	<script src="/assets/js/tags-manager.js"></script>
 	<script src="/assets/js/form-validation.js"></script>


### PR DESCRIPTION
This prevents a small information leak where filepicker.io gets some information about mamute users (IP, browser, etc) even when the inhouse upload is enabled.