### PR TITLE
Fix comment notification mail

### DIFF
--- a/src/main/java/org/mamute/notification/NotificationMailer.java
+++ b/src/main/java/org/mamute/notification/NotificationMailer.java
@@ -1,6 +1,5 @@
 package org.mamute.notification;
 
-import static java.text.MessageFormat.format;
 import static org.joda.time.format.DateTimeFormat.forPattern;
 
 import java.lang.reflect.Method;
@@ -61,7 +60,7 @@ public class NotificationMailer {
 		DateTimeFormatter dateFormat = forPattern("MMM, dd").withLocale(new Locale("pt", "br"));
 		EmailAction action = notificationMail.getAction();
 		User to = notificationMail.getTo();
-		Email email = templates.template(notificationMail.getEmailTemplate())
+		Email email = templates.template(notificationMail.getEmailTemplate(), bundle.getMessage("site.name"), action.getMainThread().getTitle())
 				.with("emailAction", action)
 				.with("dateFormat", dateFormat)
 				.with("sanitizer", POLICY)
@@ -69,8 +68,7 @@ public class NotificationMailer {
 				.with("watcher", to)
 				.with("linkerHelper", new LinkToHelper(router, brutalEnv))
 				.with("logoUrl", env.get("mail_logo_url"))
-				.to(to.getName(), to.getEmail())
-				.setSubject(format(bundle.getMessage("answer_notification_mail"), bundle.getMessage("site.name"), action.getMainThread().getTitle()));
+				.to(to.getName(), to.getEmail());
 		return email;
 	}
     

--- a/src/main/resources/mamute-messages.properties
+++ b/src/main/resources/mamute-messages.properties
@@ -607,6 +607,7 @@ gravatar.url = http://br.gravatar.com
 
 # NOTIFICATIONS MAIL
 answer_notification_mail = [{0}] New update at {1}
+comment_notification_mail = [{0}] New comment at {1}
 notification_mail.welcome = Welcome {0}, 
 notification_mail.where = There are updates in: "<a href=\"{0}\">{1}</a>"
 notification_mail.answer = {0} make a new answer: <i>"{1}"</i>

--- a/src/main/resources/mamute-messages_de.properties
+++ b/src/main/resources/mamute-messages_de.properties
@@ -606,6 +606,7 @@ gravatar.url = https://de.gravatar.com
 
 # NOTIFICATIONS MAIL
 answer_notification_mail = [{0}] Neues Update für {1}
+comment_notification_mail = [{0}] Neuer Kommentar für {1}
 notification_mail.welcome = Willkommen {0}, 
 notification_mail.where = Es gibt Updates für: "<a href=\"{0}\">{1}</a>"
 notification_mail.answer = {0} stellte eine neue Frage: <i>"{1}"</i>

--- a/src/main/resources/mamute-messages_pt_BR.properties
+++ b/src/main/resources/mamute-messages_pt_BR.properties
@@ -588,6 +588,7 @@ gravatar.url = http://br.gravatar.com
 
 # NOTIFICATIONS MAIL
 answer_notification_mail = [{0}] Atualização em {1}
+comment_notification_mail = [{0}] Comentário em {1}
 notification_mail.welcome = Ol&aacute; {0},
 notification_mail.where = H&aacute; novas atualiza&ccedil;&otilde;es em: "<a href=\"{0}\">{1}</a>"
 notification_mail.answer = {0} fez uma nova resposta: <i>"{1}"</i>


### PR DESCRIPTION
The first commit fixes an exception when sending the comment notification mail:
```
java.lang.RuntimeException: java.lang.IllegalArgumentException: Subject not defined for email template : comment_notification_mail
        at br.com.caelum.vraptor.simplemail.template.DefaultTemplateMail.prepareEmail(DefaultTemplateMail.java:99)
        at br.com.caelum.vraptor.simplemail.template.DefaultTemplateMail.to(DefaultTemplateMail.java:66)
        at org.mamute.notification.NotificationMailer.buildEmail(NotificationMailer.java:72)
        at org.mamute.notification.NotificationMailer.send(NotificationMailer.java:51)
        at org.mamute.notification.NotificationManager$SendNotifications$1.insideRequest(NotificationManager.java:84)
        at org.mamute.notification.NotificationManager$SendNotifications$1.insideRequest(NotificationManager.java:1)
        at org.mamute.components.CDIFakeRequestProvider.insideRequest(CDIFakeRequestProvider.java:30)
        at org.mamute.notification.NotificationManager$SendNotifications.run(NotificationManager.java:77)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:615)
        at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalArgumentException: Subject not defined for email template : comment_notification_mail
        at br.com.caelum.vraptor.simplemail.template.DefaultTemplateMail.prepareEmail(DefaultTemplateMail.java:92)
        ... 10 more
```

The second commit fixes the subject of the same email.