### PR TITLE
Fix URL in pagers when using e.g. ssl proxy

### DIFF
--- a/src/main/java/org/mamute/providers/DefaultViewObjects.java
+++ b/src/main/java/org/mamute/providers/DefaultViewObjects.java
@@ -59,12 +59,12 @@ public class DefaultViewObjects {
 	}
 
 	private String getCurrentUrl() {
-		String host = req.getHeader("Host");
+		String host = env.get("host");
 		String url;
 		if (host == null) {
 			url = req.getRequestURL().toString();
 		} else {
-			url = "http://" + host + req.getRequestURI();
+			url = host + "/" + req.getRequestURI();
 		}
 		if(url.endsWith("/")) url = url.split(SLASH_AT_END)[0];
 		return url;


### PR DESCRIPTION
Use the configured host and protocol instead of the one
from the headers.

When using the request's host and a hardcoded protocol ("http"), the resulting URLs would be wrong, especially when using a proxy server.