### PR TITLE
Hide the "login required" message after LDAP SSO

### DIFF
--- a/src/main/java/org/mamute/brutauth/auth/handlers/LoggedHandler.java
+++ b/src/main/java/org/mamute/brutauth/auth/handlers/LoggedHandler.java
@@ -25,7 +25,7 @@ public class LoggedHandler implements RuleHandler {
 		if("application/json".equals(req.getHeader("Accept"))){
 			result.use(Results.http()).body(bundle.getMessage("error.requires_login")).sendError(403);			
 		}else{
-			result.include("mamuteMessages", asList(messageFactory.build("alert", "auth.access.denied")));
+			result.include("loginRequiredMessages", asList(messageFactory.build("alert", "auth.access.denied")));
 			String redirectUrl = req.getRequestURL().toString();
 			result.redirectTo(AuthController.class).loginForm(redirectUrl);
 		}

--- a/src/main/java/org/mamute/controllers/AuthController.java
+++ b/src/main/java/org/mamute/controllers/AuthController.java
@@ -1,8 +1,9 @@
 package org.mamute.controllers;
 
+import java.util.Collections;
+
 import javax.inject.Inject;
 
-import br.com.caelum.vraptor.environment.Environment;
 import org.mamute.auth.AuthenticationException;
 import org.mamute.auth.Authenticator;
 import org.mamute.auth.FacebookAuthService;
@@ -27,7 +28,6 @@ public class AuthController extends BaseController {
 	@Inject	private FacebookAuthService facebook;
 	@Inject	private GoogleAuthService google;
 	@Inject	private Result result;
-	@Inject	private Environment env;
 	@Inject	private UrlValidator urlValidator;
 	@Inject	private LoginValidator validator;
 	@Inject private LoggedUser loggedUser;
@@ -36,6 +36,7 @@ public class AuthController extends BaseController {
 	@Get
 	public void loginForm(String redirectUrl) {
 		if (loggedUser.isLoggedIn()) {
+			result.include("loginRequiredMessages", Collections.emptyList());
 			redirectToRightUrl(redirectUrl);
 		} else {
 			String facebookUrl = facebook.getOauthUrl(redirectUrl);

--- a/src/main/webapp/WEB-INF/tags/header.tag
+++ b/src/main/webapp/WEB-INF/tags/header.tag
@@ -91,5 +91,6 @@
 	<tags:brutal-include value="header" />
 
 	<div class="container">
+		<tags:messages messagesList="${loginRequiredMessages}" />
 		<tags:messages messagesList="${mamuteMessages}" />
 		<tags:messages messagesList="${errors}" />


### PR DESCRIPTION
In case of LDAP SSO the user is trying to access Mamute (while still not
authenticated via LDAP SSO). The user is then redirected to the login
where LDAP SSO is enabled. When the request reaches AuthController the
user is already logged in and redirected to the page where he/she came
from. Unfortunately the "you must be logged in" message was still shown
in this case. Fix this by clearing the message in such cases.