### PR TITLE
SSL, news hiding, and login redirect fixes

### DIFF
--- a/src/main/java/org/mamute/model/User.java
+++ b/src/main/java/org/mamute/model/User.java
@@ -254,7 +254,7 @@ public class User implements Identifiable {
 		String size = width + "x" + height;
 		if (photoUri == null) {
 			String digest = Digester.md5(email);
-			String robohash = "http://robohash.org/size_"+size+"/set_set1/bgset_any/"+digest+".png";
+			String robohash = "https://robohash.org/size_"+size+"/set_set1/bgset_any/"+digest+".png";
 			String gravatar = gravatarUrl + "/avatar/" + digest + ".png?r=PG&size=" + size;
 			try {
 				return gravatar + "&d=" + java.net.URLEncoder.encode(robohash, "UTF-8");

--- a/src/main/java/org/mamute/providers/DefaultViewObjects.java
+++ b/src/main/java/org/mamute/providers/DefaultViewObjects.java
@@ -64,7 +64,7 @@ public class DefaultViewObjects {
 		if (host == null) {
 			url = req.getRequestURL().toString();
 		} else {
-			url = host + "/" + req.getRequestURI();
+			url = host + req.getRequestURI();
 		}
 		if(url.endsWith("/")) url = url.split(SLASH_AT_END)[0];
 		return url;

--- a/src/main/resources/mamute.properties
+++ b/src/main/resources/mamute.properties
@@ -149,8 +149,8 @@ attachments.root.fs.path = /tmp
 # show logout button in the user profile instead of in the main menu
 feature.logout_concealed=false
 
-# show thew News button on the header of each page, false to hide it
-feature.navigation.show_news=true
+# can set to true to hide the news navigation link
+feature.navigation.hide_news=false
 
 # permission rules
 permission.rule.create_comment = 0

--- a/src/main/resources/mamute.properties
+++ b/src/main/resources/mamute.properties
@@ -149,6 +149,9 @@ attachments.root.fs.path = /tmp
 # show logout button in the user profile instead of in the main menu
 feature.logout_concealed=false
 
+# show thew News button on the header of each page, false to hide it
+feature.navigation.show_news=true
+
 # permission rules
 permission.rule.create_comment = 0
 permission.rule.vote_up = 10

--- a/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
+++ b/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
@@ -28,7 +28,7 @@
 							${t['menu.users']}
 						</a>
 					</li>
-					<c:if test="${env.supports('feature.navigation.show_news')}">
+					<c:if test="${not env.supports('feature.navigation.hide_news')}">
 						<li class="nav-item">
 							<a class="button ${not empty newsActive ? 'current' : ''}" href="${linkTo[ListController].news}">
 								${t['menu.news']}

--- a/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
+++ b/src/main/webapp/WEB-INF/jsp/theme/default/header.jspf
@@ -28,11 +28,13 @@
 							${t['menu.users']}
 						</a>
 					</li>
-					<li class="nav-item">
-						<a class="button ${not empty newsActive ? 'current' : ''}" href="${linkTo[ListController].news}">
-							${t['menu.news']}
-						</a>
-					</li>
+					<c:if test="${env.supports('feature.navigation.show_news')}">
+						<li class="nav-item">
+							<a class="button ${not empty newsActive ? 'current' : ''}" href="${linkTo[ListController].news}">
+								${t['menu.news']}
+							</a>
+						</li>
+					</c:if>
 					<li class="ask nav-item">
 						<a class="button ask-a-question" href='${linkTo[QuestionController].newQuestion}'>
 							${t['menu.question.ask']}

--- a/src/test/java/org/mamute/model/UserTest.java
+++ b/src/test/java/org/mamute/model/UserTest.java
@@ -132,7 +132,7 @@ public class UserTest extends TestCase {
 	public void should_have_PG_gravatar_with_robotar_when_null_photo() throws Exception {
 		User user = user("name", "paulo@paulo.com.br");
 		String photo = user.getPhoto(64, 64, "http://www.gravatar.com");
-		assertEquals("http://www.gravatar.com/avatar/620ad6ac2c42fce964bbf2e01e87c04b.png?r=PG&size=64x64&d=http%3A%2F%2Frobohash.org%2Fsize_64x64%2Fset_set1%2Fbgset_any%2F620ad6ac2c42fce964bbf2e01e87c04b.png", photo);
+		assertEquals("http://www.gravatar.com/avatar/620ad6ac2c42fce964bbf2e01e87c04b.png?r=PG&size=64x64&d=https%3A%2F%2Frobohash.org%2Fsize_64x64%2Fset_set1%2Fbgset_any%2F620ad6ac2c42fce964bbf2e01e87c04b.png", photo);
 	}
 
 	@Test


### PR DESCRIPTION
PR for a handful of small issues: 

1. Gravatar/Robohash image will now use https by default. Also in my configuration I use a protocol-relative for gravatar so that it will use https if that's what the current protocol is. As an example, here's my value: `gravatar.avatar.url=//www.gravatar.com`
2. There was a bug with the redirectUrl when logging in from a question directly. It was adding an extra slash and going nowhere. The URI will always start with a forward slash so we don't need it. The redirectUrl isn't used on the main login form, so there's no effect there
3. Added new option to hide news navigation link
4. Update UserTest unit test to reflect https URL in robohash