### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ PagPag.pem
 *.iws
 *.ipr
 *.ids
-mamute.iml
+*.iml
 *.swp
 vraptor-console.sh
 .vraptor-console/


### PR DESCRIPTION
`*.iml` is better for cases when a user renames this project. IntelliJ deletes `mamute.iml` file and creates another `.iml` file.