### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 Mamute QA [![Build Status](https://secure.travis-ci.org/caelum/mamute.png)](http://travis-ci.org/caelum/mamute)
 ======
 
-##How to set up an instance of mamute
+## How to set up an instance of mamute
 
 First of all, you need to setup an MySQL database. The default database name is 
 `mamute_development`, the username is `root` and the password must be blank.
 
-##To use mamute
+## To use mamute
 
-###Using a compiled war file:
+### Using a compiled war file:
 
 1. Download the war of the latest version at http://www.mamute.org
 2. Unpack it to a folder named `yourproject/mamute`
 3. Run it by executing the bash script `mamute/run.sh`
 4. If everything worked, you are free to customize `mamute` folder as you want to! 
 
-###Using git + maven:
+### Using git + maven:
 
 1. Clone the repository from [github](https://github.com/caelum/mamute)
 2. Install node and npm
@@ -26,7 +26,7 @@ First of all, you need to setup an MySQL database. The default database name is
 8. Run it by executing the bash script `mamute/run.sh`
 9. If everything worked, you are free to customize `mamute` folder as you want to! 
 
-##To contribute with mamute:
+## To contribute with mamute:
 
 1. Fork the repository from [github](https://github.com/caelum/mamute)
 2. Clone the fork
@@ -36,7 +36,7 @@ First of all, you need to setup an MySQL database. The default database name is
 6. Run `Main.java` to start mamute
 7. Develop and do your pull request
 
-##FAQ
+## FAQ
 
 * [How to setup an instance](http://meta.mamute.org/221-how-to-set-up-an-instance-of-mamute)
 
@@ -55,7 +55,7 @@ First of all, you need to setup an MySQL database. The default database name is
 * [What are the basic CSS classes to customize Mamute?](http://meta.mamute.org/281-what-are-the-basic-css-classes-to-customize-mamute)
 
 
-##Questions?
+## Questions?
 
 Send your questions to [mamute meta](http://meta.mamute.org).
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
