### PR TITLE
Fix flaky test

### DIFF
--- a/src/main/java/org/mamute/dao/TagDAO.java
+++ b/src/main/java/org/mamute/dao/TagDAO.java
@@ -40,7 +40,7 @@ public class TagDAO {
 	public List<TagUsage> getRecentTagsSince(DateTime since, int maxResult) {
 		Query query = session.createQuery("select new org.mamute.model.TagUsage(tag, count(question)) from Question question " +
 				"join question.information.tags tag " +
-				"where question.lastUpdatedAt > :since  group by tag order by count(question) desc");
+				"where question.lastUpdatedAt > :since  group by tag order by count(question) desc, name");
 		query.setParameter("since", since);
 		return query.setMaxResults(maxResult).list();
 	}

--- a/src/test/java/org/mamute/dao/DatabaseTestCase.java
+++ b/src/test/java/org/mamute/dao/DatabaseTestCase.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 
 import javax.validation.ValidatorFactory;
 
+import org.apache.log4j.Logger;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.junit.After;
@@ -21,6 +22,7 @@ import br.com.caelum.vraptor.environment.Environment;
 
 @SuppressWarnings("unchecked")
 public abstract class DatabaseTestCase extends CDITestCase{
+	private static Logger LOG = Logger.getLogger(DatabaseTestCase.class);
 	protected static final SessionFactory factory;
 	private static final SessionFactoryCreator creator;
 	protected Session session;
@@ -33,8 +35,10 @@ public abstract class DatabaseTestCase extends CDITestCase{
 			MamuteDatabaseConfiguration configuration = new MamuteDatabaseConfiguration(testing, vf, null);
 			configuration.init();
 			creator = new SessionFactoryCreator(configuration);
+			LOG.info("Initializing database (SessionFactoryCreator) ...");
 			creator.init();
 			factory = creator.getInstance();
+			LOG.info("Database initialized.");
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}

--- a/src/test/java/org/mamute/dao/TagDAOTest.java
+++ b/src/test/java/org/mamute/dao/TagDAOTest.java
@@ -46,8 +46,8 @@ public class TagDAOTest extends DatabaseTestCase{
 		assertEquals(2, recentTagsUsage.size());
 		assertEquals(2L, recentTagsUsage.get(0).getUsage().longValue());
 		assertEquals(1L, recentTagsUsage.get(1).getUsage().longValue());
-		assertEquals(java.getId(), recentTagsUsage.get(0).getTag().getId());
-		assertEquals(ruby.getId(), recentTagsUsage.get(1).getTag().getId());
+		assertEquals("java tag should be the most used", java.getId(), recentTagsUsage.get(0).getTag().getId());
+		assertEquals("ruby tag should be the second-most used", ruby.getId(), recentTagsUsage.get(1).getTag().getId());
 	}
 	
 	@Test


### PR DESCRIPTION
The `should_load_recent_tags_used` test sometimes produced a false negative because the ordering of the tags was non-deterministic.  Fix the ordering by adding a second sort field (the name of the tag).